### PR TITLE
全てのresource間で勝手にrefするようにした

### DIFF
--- a/lib/mixins/resource_mix.js
+++ b/lib/mixins/resource_mix.js
@@ -29,17 +29,29 @@ function resourceMix (BaseClass) {
      * Get a resource with name
      * @param {string|Object} resourceName - Name of resource
      * @param {Object} [options={}] - Optional settings
+     * @param {boolean} [options.renew] - Use no cache
      * @returns {ClayResource}
      */
     resource (resourceName, options = {}) {
       const s = this
+      let { renew = false } = options
       resourceName = String(clayResourceName(resourceName))
       const { driver } = s
+      if (renew) {
+        delete s._resources[ resourceName ]
+      }
       let cached = s._resources[ resourceName ]
       if (cached) {
         return cached
       }
-      const resource = clayResource.fromDriver(driver, resourceName, options)
+      let knownResources = Object.keys(s._resources).map((name) => s._resources[ name ])
+      let resource = clayResource.fromDriver(driver, resourceName, {
+        annotates: true,
+        refs: knownResources
+      })
+      for (let knownResource of knownResources) {
+        knownResource.refs(resource)
+      }
       s._resources[ resourceName ] = resource
       return resource
     }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clay-lump",
-  "version": "3.0.3",
+  "version": "3.1.0",
   "description": "Lump of clay-db",
   "main": "lib",
   "browser": "ci/browser",

--- a/test/clay_lump_test.js
+++ b/test/clay_lump_test.js
@@ -70,6 +70,19 @@ describe('clay-lump', function () {
       }
     }
   }))
+
+  it('Auto Refs', () => co(function * () {
+    let lump01 = new ClayLump('lump-01', {})
+    let Org = lump01.resource('Org')
+    let User = lump01.resource('User')
+    let org01 = yield Org.create({ name: 'org01' })
+    let user01 = yield User.create({ name: 'user01', org: org01 })
+
+    let user01AsOne = yield User.one(user01.id)
+    equal(user01AsOne.org.name, 'org01')
+
+    deepEqual(lump01.driver._storages.User[ user01.id ].org, { $ref: `Org#${org01.id}` })
+  }))
 })
 
 /* global describe, before, after, it */


### PR DESCRIPTION
リソースの作成時に、同じ文字列を渡すと全く同じものが返ってくることようにしたい。(`const User = lump.resource('User')`)

なので、リソース間の参照は個別指定するのではなく、勝手に全部がお互いに参照するようにした

